### PR TITLE
Added support for API 4.0, improved UpdateNotifier API

### DIFF
--- a/src/JackMD/UpdateNotifier/UpdateNotifier.php
+++ b/src/JackMD/UpdateNotifier/UpdateNotifier.php
@@ -38,24 +38,15 @@ use pocketmine\plugin\Plugin;
 class UpdateNotifier{
 
 	/**
-	 * Submits an async task which then checks if a specific version for the plugin is available.
-	 * If an update is available then it would print a message on the console.
-	 *
-	 * @param Plugin $plugin
-	 * @param string $pluginVersion
-	 */
-	public static function checkSpecificUpdate(Plugin $plugin, string $pluginVersion) : void{
-		$plugin->getLogger()->info("Checking for updates...");
-		$plugin->getServer()->getAsyncPool()->submitTask(new UpdateNotifyTask($plugin->getName(), $pluginVersion));
-	}
-
-	/**
 	 * Submits an async task which then checks if a new version for the plugin is available.
 	 * If an update is available then it would print a message on the console.
 	 *
-	 * @param Plugin $plugin
+	 * @param Plugin      $plugin
+	 * @param string|null $pluginVersion If it's null (by default), it checks the latest version else for a specific version.
 	 */
-	public static function checkUpdate(Plugin $plugin) : void{
-		self::checkSpecificUpdate($plugin, $plugin->getDescription()->getVersion());
+	public static function checkUpdate(Plugin $plugin, ?string $pluginVersion = null) : void{
+		$plugin->getLogger()->info("Checking for updates...");
+		$plugin->getServer()->getAsyncPool()->submitTask(new UpdateNotifyTask($plugin->getName(), $pluginVersion ?? $plugin->getDescription()->getVersion()));
 	}
+
 }

--- a/src/JackMD/UpdateNotifier/UpdateNotifier.php
+++ b/src/JackMD/UpdateNotifier/UpdateNotifier.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /*
  *  _   _           _       _       _   _       _   _  __ _
@@ -36,17 +36,26 @@ use JackMD\UpdateNotifier\task\UpdateNotifyTask;
 use pocketmine\plugin\Plugin;
 
 class UpdateNotifier{
-	
+
+	/**
+	 * Submits an async task which then checks if a specific version for the plugin is available.
+	 * If an update is available then it would print a message on the console.
+	 *
+	 * @param Plugin $plugin
+	 * @param string $pluginVersion
+	 */
+	public static function checkSpecificUpdate(Plugin $plugin, string $pluginVersion) : void{
+		$plugin->getLogger()->info("Checking for updates...");
+		$plugin->getServer()->getAsyncPool()->submitTask(new UpdateNotifyTask($plugin->getName(), $pluginVersion));
+	}
+
 	/**
 	 * Submits an async task which then checks if a new version for the plugin is available.
 	 * If an update is available then it would print a message on the console.
 	 *
 	 * @param Plugin $plugin
-	 * @param string $pluginName
-	 * @param string $pluginVersion
 	 */
-	public static function checkUpdate(Plugin $plugin, string $pluginName, string $pluginVersion){
-		$plugin->getLogger()->info("Checking for updates...");
-		$plugin->getServer()->getAsyncPool()->submitTask(new UpdateNotifyTask($pluginName, $pluginVersion));
+	public static function checkUpdate(Plugin $plugin) : void{
+		self::checkSpecificUpdate($plugin, $plugin->getDescription()->getVersion());
 	}
 }

--- a/src/JackMD/UpdateNotifier/task/UpdateNotifyTask.php
+++ b/src/JackMD/UpdateNotifier/task/UpdateNotifyTask.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /*
  *  _   _           _       _       _   _       _   _  __ _
@@ -37,15 +37,15 @@ use pocketmine\Server;
 use pocketmine\utils\Internet;
 
 class UpdateNotifyTask extends AsyncTask{
-	
+
 	/** @var string */
 	private const POGGIT_RELEASES_URL = "https://poggit.pmmp.io/releases.json?name=";
-	
+
 	/** @var string */
 	private $pluginName;
 	/** @var string */
 	private $pluginVersion;
-	
+
 	/**
 	 * UpdateNotifyTask constructor.
 	 *
@@ -56,8 +56,8 @@ class UpdateNotifyTask extends AsyncTask{
 		$this->pluginName = $pluginName;
 		$this->pluginVersion = $pluginVersion;
 	}
-	
-	public function onRun(): void{
+
+	public function onRun() : void{
 		$json = Internet::getURL(self::POGGIT_RELEASES_URL . $this->pluginName, 10, [], $err);
 		$highestVersion = $this->pluginVersion;
 		$artifactUrl = "";
@@ -73,16 +73,14 @@ class UpdateNotifyTask extends AsyncTask{
 				$api = $release["api"][0]["from"] . " - " . $release["api"][0]["to"];
 			}
 		}
-		
+
 		$this->setResult([$highestVersion, $artifactUrl, $api, $err]);
 	}
-	
-	/**
-	 * @param Server $server
-	 */
-	public function onCompletion(Server $server): void{
+
+
+	public function onCompletion() : void{
 		$pluginName = $this->pluginName;
-		$plugin = $server->getPluginManager()->getPlugin($pluginName);
+		$plugin = Server::getInstance()->getPluginManager()->getPlugin($pluginName);
 		if($plugin === null){
 			return;
 		}
@@ -92,6 +90,7 @@ class UpdateNotifyTask extends AsyncTask{
 		}
 		if($highestVersion === $this->pluginVersion){
 			$plugin->getLogger()->info("No new updates were found. You are using the latest version.");
+
 			return;
 		}
 		$artifactUrl = $artifactUrl . "/" . $pluginName . "_" . $highestVersion . ".phar";

--- a/virion.yml
+++ b/virion.yml
@@ -1,6 +1,6 @@
 name: UpdateNotifier
-version: 1.0.0
-api: [3.0.0]
+version: 1.1.0
+api: [4.0.0]
 antigen: JackMD\UpdateNotifier
 authors: [JackMD, Sandertv]
 php: [7.2]


### PR DESCRIPTION
This pull request added:
* Bump to version 1.1.0
* Updated to API 4.0 and removed 3.0 compatibility.
* Improved UpdateNotifier::checkUpdate(), removed useless $pluginName parameter and edited to a nullable parameter $pluginVersion. If the last one is null it checks for the last version else it compares the latest with the specified version. (I think it's not very useful but in some cases it could).